### PR TITLE
adding "static gradient" paint worklet

### DIFF
--- a/worklets/static-gradient.json
+++ b/worklets/static-gradient.json
@@ -2,28 +2,27 @@
   "workletName": "Static Gradient",
   "packageName": "static-gradient",
   "npmURL": "https://www.npmjs.com/package/houdini-static-gradient",
-  "workletUrl": "https://unpkg.com/houdini-static-gradient@1.0.1/static-gradient.worklet.js",
-  "cdnUrl": "https://unpkg.com/houdini-static-gradient@1.0.1/static-gradient.worklet.js",
+  "workletUrl": "https://unpkg.com/houdini-static-gradient@1.0.2/static.gradient.worklet.js",
+  "cdnUrl": "https://unpkg.com/houdini-static-gradient@1.0.2/static.gradient.worklet.js",
   "demoUrl": "https://glitch.com/edit/#!/houdini-static-gradient",
   "tags": ["paint", "properties and values"],
   "customProps": {
-    "--direction" : {
+    "--static-gradient-direction" : {
       "type": "string",
-      "default": "to-bottom",
+      "default": "to-top",
       "options": ["to-bottom", "to-top", "to-right", "to-left"]
     },
-    "--color" : {
+    "--static-gradient-color" : {
       "type": "color",
       "default": "#ff69b4"
     },
-    "--size": {
+    "--static-gradient-size": {
       "type": "number",
       "default": 2,
       "range": [1, 30]
     }
   },
-  "usage": "background: paint(static-gradient, to-top, hotpink, small)",
-  "html": "<div style='height:100%;width:100%;'><div style='background-image: paint(static-gradient, to-top, hotpink, small); height:100%;width:100%;'></div></div>",
+  "usage": "background: paint(static-gradient)",
   "author": {
     "name": "@argyleink",
     "url": "https://twitter.com/argyleink",


### PR DESCRIPTION
I decided it was better to try and be close to gradient syntax which meant that I didnt use any properties. Now that I'm in the project.. looks like our demo's are pretty much only ready for properties and not arguments! DOH! so maybe this will hang for a bit as we decide how to handle arguments values vs properties? Also, really annoying that using a custom property as a value in a custom paint function doesnt work..? Open to help here!

```css
.demo {
  background: paint(static-gradient, to-top, hotpink, small);
  background: paint(static-gradient, to-right, hsl(200 50% 50%), 6);
  background: paint(static-gradient, to-bottom, #fff, large);
}
```

![image](https://user-images.githubusercontent.com/1134620/95137764-a8a89a80-071d-11eb-9a72-1b1c85cfd4b6.png)
