### PR TITLE
Avoid repaints on hover

### DIFF
--- a/public/components/Card/style.module.css
+++ b/public/components/Card/style.module.css
@@ -8,12 +8,12 @@
   margin-bottom: 4rem;
   border-radius: 10px;
   margin: 0 auto;
-  transition-duration: 0.5s;
+  transition: transform 0.5s;
+  will-change: transform;
 }
 
 [type="demo"] .card:hover {
   transform: translateY(-10px);
-  box-shadow: 0px 30px 35px 0px rgba(0, 0, 0, 0.15);
 }
 
 [type="resource"] {
@@ -22,12 +22,12 @@
   background-color: #f5f5f5;
   border-radius: 10px;
   width: calc(100% - 4rem);
-  transition-duration: 0.5s;
+  transition: transform 0.5s;
+  will-change: transform;
 }
 
 [type="resource"]:hover {
   transform: translateY(-10px);
-  box-shadow: 0px 30px 35px 0px rgba(0, 0, 0, 0.15);
 }
 
 .demoArea {


### PR DESCRIPTION
I noticed that some of the paint worklets that use random patterns repaint every frame on hover. That means one of the elements they are contained in is animating a non-composited property.

After looking at the styles it’s the animation of `box-shadow`, that causes a repaint on every frame. This PR removed the change in `box-shadow` and also adds `will-change: transform` to the cards to avoid a repaint on the first and last frame of the animation.

This obviously degrades the visual effect, but animating `box-shadow` is quite costly and can end up janking on low-end devices. If you want the shadow to animate on hover, it would be better to put the `box-shadow` on an `:after`, and use animate `scale()` instead of `box-shadow` directly.
