### PR TITLE
hotfix: ensure polyfill is loaded before trying to invoke painters

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -1,25 +1,30 @@
 <!DOCTYPE html>
 <html lang="en">
-  <head>
-    <title>Houdini.how</title>
-    <meta name="description" content="The community-driven resource library of CSS Houdini worklets. Learn about CSS Houdini, its APIs, usage, polyfills, and browser status, to take advantage of the Houdini APIs today.">
-    <meta name="keywords" content="CSS, Houdini, CSS Houdini, CSS spec, worklet, worklets, paint, paint api, properties and values, animation, layout, typed object model ">
-    <meta name="viewport" content="width=device-width, initial-scale=1">
-    <link rel="icon" href="data:,">
-    <link rel="preload" as="script" crossorigin href="/index.js">
-    <link rel="preload" as="style" href="https://fonts.googleapis.com/css2?family=Roboto+Mono:wght@400&display=swap">
-    <link rel="stylesheet" href="/style.css">
-    <!-- GA -->
-    <script>
-      window.dataLayer = window.dataLayer || [];
-      function gtag(){dataLayer.push(arguments);}
-      gtag('js', new Date());
-      gtag('config', 'G-ZLJC1T37VS');
-    </script>
-  </head>
-  <body>
-    <script type="module" src="/index.js"></script>
-    <script async defer type="module" src="/polyfills.js"></script>
-    <script async src="https://www.googletagmanager.com/gtag/js?id=G-ZLJC1T37VS"></script>
-  </body>
+
+<head>
+  <title>Houdini.how</title>
+  <meta name="description"
+    content="The community-driven resource library of CSS Houdini worklets. Learn about CSS Houdini, its APIs, usage, polyfills, and browser status, to take advantage of the Houdini APIs today.">
+  <meta name="keywords"
+    content="CSS, Houdini, CSS Houdini, CSS spec, worklet, worklets, paint, paint api, properties and values, animation, layout, typed object model ">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <link rel="icon" href="data:,">
+  <link rel="preload" as="script" crossorigin href="/index.js">
+  <link rel="preload" as="style" href="https://fonts.googleapis.com/css2?family=Roboto+Mono:wght@400&display=swap">
+  <link rel="stylesheet" href="/style.css">
+  <!-- GA -->
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag() { dataLayer.push(arguments); }
+    gtag('js', new Date());
+    gtag('config', 'G-ZLJC1T37VS');
+  </script>
+</head>
+
+<body>
+  <script async defer type="module" src="/index.js"></script>
+  <script type="module" src="/polyfills.js"></script>
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-ZLJC1T37VS"></script>
+</body>
+
 </html>


### PR DESCRIPTION
Looks like I must have borked the stylesheet insertion detection logic in the polyfill. I'll try to get that fixed.