### PR TITLE
Update polyfill to fix element geometry on non-retina screens

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,12 +10,18 @@
       "dev": true
     },
     "css-paint-polyfill": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/css-paint-polyfill/-/css-paint-polyfill-3.1.3.tgz",
-      "integrity": "sha512-qwb0Pce7YXfEiJXS+AjYOMAW5EPut9Pk56w1hgWv0BxgVGRqNEX0nuB2nVHkxP0xJrCpGF2TbxXNfN++Nk1wig==",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/css-paint-polyfill/-/css-paint-polyfill-3.1.4.tgz",
+      "integrity": "sha512-RWFlW51lamq0b3JecOdY0PYbN5glBzz/js+Ec/Ic1aR9Pw+Enh0RAF+yW1SfEN3MlDh56VQ307HYlTkUHrP9oA==",
       "requires": {
         "transpiler-lite": "git+https://gist.github.com/781ef9620da8a30228b9f0c6e21fa7f6.git"
       }
+    },
+    "fsevents": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.2.1.tgz",
+      "integrity": "sha512-bTLYHSeC0UH/EFXS9KqWnXuOl/wHK5Z/d+ghd5AsFMYN7wIGkUCOJyzy88+wJKkZPGON8u4Z9f6U4FdgURE9qA==",
+      "optional": true
     },
     "json5": {
       "version": "2.1.3",
@@ -39,7 +45,10 @@
     "wmr": {
       "version": "0.0.12",
       "resolved": "https://registry.npmjs.org/wmr/-/wmr-0.0.12.tgz",
-      "integrity": "sha512-+JXnuG6Mx99vdrGP1V4de3QVL+FJWt66DWfKmPpnTgFWw0uWPMj8+VC+VS5xV3A2IxLrdtFZfEt8B9gURoI8hQ=="
+      "integrity": "sha512-+JXnuG6Mx99vdrGP1V4de3QVL+FJWt66DWfKmPpnTgFWw0uWPMj8+VC+VS5xV3A2IxLrdtFZfEt8B9gURoI8hQ==",
+      "requires": {
+        "fsevents": "^2.1.3"
+      }
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "resources:watch": "node ./resources/_build.js watch"
   },
   "dependencies": {
-    "css-paint-polyfill": "^3.1.3",
+    "css-paint-polyfill": "^3.1.4",
     "wmr": "0.0.12"
   },
   "devDependencies": {


### PR DESCRIPTION
Update css-paint-polyfill to 3.1.4, which fixes two bugs in the geometry calculations.