### PR TITLE
Update to css-paint-polyfill@3.2.0 to fix border-image in Safari/Firefox

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,13 +6,12 @@
     "clsx": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/clsx/-/clsx-1.1.1.tgz",
-      "integrity": "sha512-6/bPho624p3S2pMyvP5kKBPXnI3ufHLObBFCfgx+LkeR5lg2XYy2hqZqUf45ypD8COn2bhgGJSUE+l5dhNBieA==",
-      "dev": true
+      "integrity": "sha512-6/bPho624p3S2pMyvP5kKBPXnI3ufHLObBFCfgx+LkeR5lg2XYy2hqZqUf45ypD8COn2bhgGJSUE+l5dhNBieA=="
     },
     "css-paint-polyfill": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/css-paint-polyfill/-/css-paint-polyfill-3.1.4.tgz",
-      "integrity": "sha512-RWFlW51lamq0b3JecOdY0PYbN5glBzz/js+Ec/Ic1aR9Pw+Enh0RAF+yW1SfEN3MlDh56VQ307HYlTkUHrP9oA==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/css-paint-polyfill/-/css-paint-polyfill-3.2.0.tgz",
+      "integrity": "sha512-66+yhe1PKCzUogHF/PbRlFhM7kHONl0/GlLdY6TViDK0Rt0pcf+S7PqGwh8Rp5nl72iItaiVVrx7q8GrBnE5rw==",
       "requires": {
         "transpiler-lite": "git+https://gist.github.com/781ef9620da8a30228b9f0c6e21fa7f6.git"
       }

--- a/package.json
+++ b/package.json
@@ -10,12 +10,12 @@
     "resources:watch": "node ./resources/_build.js watch"
   },
   "dependencies": {
-    "css-paint-polyfill": "^3.1.4",
+    "clsx": "^1.1.1",
+    "css-paint-polyfill": "^3.2.0",
     "preact-iso": "^0.2.0",
     "wmr": "^1.0.0"
   },
   "devDependencies": {
-    "clsx": "^1.1.1",
     "json5": "^2.1.3"
   }
 }


### PR DESCRIPTION
The only way to fix geometry calculations for border-image in Safari was to disable hidpi/retina painting, since it seems Webkit does not respect DPR when calculating the effective image slice for `-webkit-canvas`-derived border images. The polyfill injects `image-rendering:optimizeSpeed` to make things look a little less blurry than the default value in Safari.

**Note:** there is a separate PR to `css-houdini-lines` to fix the color issue, it wasn't a bug in the polyfill.