### PR TITLE
fix: Typo in npmURL to npmUrl

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,7 +17,7 @@ To contribute a Houdini worklet, create a new file within `worklets/`. The infor
 {
   "workletName": "title of worklet",
   "packageName": "name of npm package",
-  "npmURL": "url of npm package",
+  "npmUrl": "url of npm package",
   "cdnUrl": "url of cdn-hosted package",  // if hosted on npm, use unpkg
   "demoUrl": "url of worklet demo",
   // which type(s) of worklets this uses


### PR DESCRIPTION
- Npm links not detected wth the template key.