### PR TITLE
Added a new variance to Leaf example

### DIFF
--- a/worklets/houdini-leaf.json
+++ b/worklets/houdini-leaf.json
@@ -14,6 +14,11 @@
       "type": "number",
       "default": "16",
       "range": [5, 50]
+    },
+    "--leaf-variance": {
+      "type": "string",
+      "default": "left",
+      "options": ["left", "around"]
     }
   },
   "usage": "background-image: paint(leaf);",


### PR DESCRIPTION
The new variance introduces a rounded boarder with the leaf and vine effect. 
![Leaf with variances](https://user-images.githubusercontent.com/6165894/102364413-68b72c80-3f84-11eb-8dcb-da560b34819f.png)
