### PR TITLE
Load worklets using CSS.paintWorklet.addModule

### DIFF
--- a/public/components/Demo/index.js
+++ b/public/components/Demo/index.js
@@ -53,17 +53,26 @@ function styleObjectToString(styleObj) {
 }
 
 const injected = new Map()
-function injectWorkletScript(url) {
+function injectWorkletScript(url, type = 'worklet') {
   let p = injected.get(url)
   if (p) return p
-  p = new Promise((resolve, reject) => {
-    const script = document.createElement("script")
-    script.async = true;
-    script.src = url
-    script.onload = resolve
-    script.onerror = reject
-    document.head.appendChild(script)
-  })
+  switch (type) {
+    case 'script':
+        p = new Promise((resolve, reject) => {
+          const script = document.createElement("script")
+          script.async = true;
+          script.src = url
+          script.onload = resolve
+          script.onerror = reject
+          document.head.appendChild(script)
+        })
+      break;
+
+    case 'worklet':
+    default:
+      p = CSS.paintWorklet.addModule(url)
+      break;
+  }
   injected.set(url, p)
   return p
 }
@@ -121,7 +130,7 @@ export default class Demo extends Component {
 
   loadWorklet() {
     const { worklet } = this.props
-    injectWorkletScript(worklet.cdnUrl || worklet.workletUrl).catch(String).then(() => {
+    injectWorkletScript(worklet.cdnUrl || worklet.workletUrl, worklet.cdnUrlType).catch(String).then(() => {
       this.setState({ isLoaded: true })
     })
     if (this.obs) {

--- a/worklets/houdini-leaf.json
+++ b/worklets/houdini-leaf.json
@@ -1,6 +1,7 @@
 {
   "workletName": "Houdini Leaf",
   "packageName": "houdini-leaf",
+  "cdnUrlType": "script",
   "cdnUrl": "https://unpkg.com/houdini-leaf",
   "npmUrl": "https://www.npmjs.com/package/houdini-leaf",
   "demoUrl": "https://codepen.io/zhua/pen/LYRxxJK",


### PR DESCRIPTION
I'm currently trying to add [`css-houdin-voronoi`](https://github.com/bramus/css-houdini-voronoi) to the list of demo worklets (see [this separate branch](https://github.com/bramus/houdini.how/tree/add-css-houdini-voronoi)). While the addition of the JSON is straightforward, I am however greeted with an `"Uncaught ReferenceError: Voronoi is not defined"` error.

I took me some time to figure out but found that this is caused by the way how worklets are loaded, in combination with how `css-houdini-voronoi` is structured.
1. The worklets get injected as scripts tags: https://github.com/GoogleChromeLabs/houdini.how/blob/main/public/components/Demo/index.js#L56
1. As those scripts call `registerPaint` (normally fromo `CSS.paintWorklet`), this method is being manually implemented in the `window` scope: https://github.com/GoogleChromeLabs/houdini.how/blob/main/public/index.js#L19
- `css-houdini-voronoi` uses an extra library which the painter uses. This extra function/class is placed adjacent to the `registerPaint` call found inside the `worklet.js` file.

As here on houdini.how the `window.registerPaint` is being called from within the script loaded `worklet.js`, and that `registerPaint` calling `CSS.paintWorklet.addModule()` with only the painter, the painter no longer has access to the extra library which `css-houdini-voronoi` requires.

This PR fixes that behavior by simply loading the paint worklets using `CSS.paintWorklet.addModule`. As that's also a promise, nothing else in the logic of the `Demo` component needs to change.

~~⚠️ However, if merging this PR would be considered: I've noticed the leaf demo breaks on this change. It spits out a `"Uncaught ReferenceError: CSS is not defined"`. That's because that worklet checks for `registerPaint` being available in `CSS` before calling it. I don't think this is customary for a worklet to do so? Furthermore that demo calls `window.CSS.paintWorklet.addModule(workletBlob);` itself, which also doesn't seem customary. All other paint worklet demos — including the `css-houdin-voronoi` one which I want to add — work fine.~~ Fixed with an extra commit.



