### PR TITLE
Add usage with Vite

### DIFF
--- a/public/pages/usage/index.js
+++ b/public/pages/usage/index.js
@@ -82,6 +82,15 @@ export default function UsagePage() {
           CSS.paintWorklet.addModule(workletURL);`}}></code></pre>
           </div>
           <div>
+            <h4>Vite</h4>
+
+            <pre class={style.js}><code dangerouslySetInnerHTML={{
+              __html:
+                `import workletURL from "&lt;package-name&gt/worklet.js?url"
+
+            CSS.paintWorklet.addModule(workletURL);`}}></code></pre>
+          </div>
+          <div>
             <h4>Webpack 4 and 5</h4>
             <pre class={style.js}><code dangerouslySetInnerHTML={{ __html:
           `import workletURL from "url-loader!&lt;package-name&gt/worklet.js"


### PR DESCRIPTION
Resolves #152 

Here is an example working using @una's wonderful extra-scalloped-border 
https://github.com/matias-capeletto/vite-houdini-how

![image](https://user-images.githubusercontent.com/583075/106385011-4a8b7b80-63ce-11eb-9668-3ad27a4f98ec.png)

Note: I placed the new section second on the list so the box would align with WMR and Parcel. 