### PR TITLE
Parcel detects paint worklets automatically with `new URL(..., import.meta.url)`

### DIFF
--- a/public/pages/usage/index.js
+++ b/public/pages/usage/index.js
@@ -74,12 +74,18 @@ export default function UsagePage() {
 
         <div class={style.installation}>
           <div>
-          <h4>Parcel and WMR</h4>
+          <h4>WMR</h4>
 
           <pre class={style.js}><code dangerouslySetInnerHTML={{ __html:
             `import workletURL from "url:&lt;package-name&gt/worklet.js"
 
           CSS.paintWorklet.addModule(workletURL);`}}></code></pre>
+          </div>
+          <div>
+          <h4>Parcel</h4>
+
+          <pre class={style.js}><code dangerouslySetInnerHTML={{ __html:
+            `CSS.paintWorklet.addModule(new URL("npm:&lt;package-name&gt/worklet.js", import.meta.url));`}}></code></pre>
           </div>
           <div>
             <h4>Vite</h4>


### PR DESCRIPTION
https://parceljs.org/blog/rc0/#worklet-support

For example, this works with Parcel 2 (the URL constructor call has to happen in the `addModule` argument, and the filepath has to be a string literal):
```html
<!DOCTYPE html>
<html>
	<head>
		<title></title>
		<style>
			.demo {
				--border-radius-reverse: 10;

				--border-radius-reverse-color: orange;

				border: calc(var(--border-radius-reverse) * 1px) solid
					transparent;
				border-image: paint(border-radius-reverse);
				border-image-slice: var(--border-radius-reverse);

				width:  100px;
				height:  100px;
			}
		</style>
	</head>
	<body>
		<div class="demo"></div>
		<script type="module">
			CSS.paintWorklet.addModule(
				new URL(
					"npm:@houdini-modules/border-radius-reverse",
					import.meta.url
				)
			);
		</script>
	</body>
</html>
```

Unrelated to that, I find the `/worklet.js` suffix a bit misleading, because for example `@houdini-modules/border-radius-reverse` doesn't contain such a file.